### PR TITLE
Fix edit device after alignment position not correct problem.

### DIFF
--- a/DataModule/CalcUtils.hpp
+++ b/DataModule/CalcUtils.hpp
@@ -31,10 +31,20 @@ public:
 
     template<typename T>
     static inline bool isRectInRect(const cv::Rect_<T> &rectIn, const cv::Rect_<T> &rectOut) {
-    if (rectOut.contains(rectIn.tl()) && rectOut.contains(rectIn.br()))
-        return true;
-    return false;
-}
+        if (rectOut.contains(rectIn.tl()) && rectOut.contains(rectIn.br()))
+            return true;
+        return false;
+    }
+
+    template<typename _Tp>
+    static inline cv::Point2f warpPoint(const cv::Mat &matWarp, const cv::Point2f &ptInput) {
+        cv::Mat matPoint = cv::Mat::zeros(3, 1, matWarp.type());
+        matPoint.at<_Tp>(0, 0) = ptInput.x;
+        matPoint.at<_Tp>(1, 0) = ptInput.y;
+        matPoint.at<_Tp>(2, 0) = 1.f;
+        cv::Mat matResult = matWarp * matPoint;
+        return cv::Point_<_Tp>(matResult.at<_Tp>(0, 0), matResult.at<_Tp>(1, 0));
+    }
 
 private:
     CalcUtils();

--- a/DataModule/DataCtrl.cpp
+++ b/DataModule/DataCtrl.cpp
@@ -1217,3 +1217,11 @@ void DataCtrl::setCombinedBigResult(const Vision::VectorOfMat &vecCombinedBigIma
     m_vecCombinedBigImages = vecCombinedBigImages;
     m_matCombinedBigHeight = matHeight;
 }
+
+void DataCtrl::getCadOffsetPixel(float& fOffsetX, float& fOffsetY) const {
+    fOffsetX = 0.f; fOffsetY = 0.f;
+    if (!m_matCadTransform.empty()) {
+        fOffsetX = m_matCadTransform.at<float>(0, 2);
+        fOffsetY = m_matCadTransform.at<float>(1, 2);
+    }
+}

--- a/DataModule/DataCtrl.h
+++ b/DataModule/DataCtrl.h
@@ -55,6 +55,9 @@ public:
     Vision::VectorOfMat getCombinedBigImages() const { return m_vecCombinedBigImages; }
     cv::Mat getCombinedBigHeight() const { return m_matCombinedBigHeight; }
     QString getDataStoreApiVersion() const { return m_strDataStoreApiVersion; }
+    inline void setCadTransform(const cv::Mat& matTranform)  { m_matCadTransform = matTranform; };
+    inline const cv::Mat& getCadTransform() const { return m_matCadTransform; };
+    void getCadOffsetPixel(float& fOffsetX, float& fOffsetY) const;
 
 private:
     void clearFiles(const QString &folderFullPath);
@@ -64,12 +67,13 @@ private:
     QMutex m_mutex;
     int m_nCycleTestNum;
 
-    QBoardObj* m_boardObj;
-    QVector<QDetectObj*> m_cellTmpObjs;
-    QVector<QDetectObj*> m_cellTestObjs;
-    QVector<QProfileObj*> m_profileObjs;
-    int m_nProfileIndex;
+    QBoardObj*              m_boardObj;
+    QVector<QDetectObj*>    m_cellTmpObjs;
+    QVector<QDetectObj*>    m_cellTestObjs;
+    QVector<QProfileObj*>   m_profileObjs;
+    int                     m_nProfileIndex;
     Vision::VectorOfMat     m_vecCombinedBigImages;
     cv::Mat                 m_matCombinedBigHeight;
     QString                 m_strDataStoreApiVersion;
+    cv::Mat                 m_matCadTransform;
 };

--- a/DataModule/DataWidget.cpp
+++ b/DataModule/DataWidget.cpp
@@ -10,10 +10,10 @@ DataWidget::DataWidget(DataCtrl *pDataCtrl, QWidget *parent)
 {
     ui.setupUi(this);
     ui.tabWidget->addTab(new ImportCADWidget(), QStringLiteral("导入CAD"));
-    ui.tabWidget->addTab(new EditCADWidget(), QStringLiteral("编辑CAD"));
+    ui.tabWidget->addTab(new EditCADWidget(pDataCtrl, this), QStringLiteral("编辑CAD"));
     ui.tabWidget->addTab(new BoardWidget(), QStringLiteral("电路板"));
     ui.tabWidget->addTab(new ScanImageWidget(pDataCtrl), QStringLiteral("扫图"));
-    ui.tabWidget->addTab(new FiducialMarkWidget(pDataCtrl), QStringLiteral("对位标记"));
+    ui.tabWidget->addTab(new FiducialMarkWidget(pDataCtrl, this), QStringLiteral("对位标记"));
 }
 
 DataWidget::~DataWidget()

--- a/DataModule/EditCADWidget.h
+++ b/DataModule/EditCADWidget.h
@@ -3,13 +3,14 @@
 
 #include <QWidget>
 #include "ui_EditCADWidget.h"
+#include "DataCtrl.h"
 
 class EditCADWidget : public QWidget
 {
     Q_OBJECT
 
 public:
-    EditCADWidget(QWidget *parent = 0);
+    EditCADWidget(DataCtrl *pDataCtrl, QWidget *parent = 0);
     ~EditCADWidget();
 
 private slots:
@@ -19,6 +20,7 @@ private slots:
 
 private:
     Ui::EditCAD ui;
+    DataCtrl                   *m_pDataCtrl;
 };
 
 #endif // EDITCAD_H

--- a/DataModule/FiducialMarkWidget.cpp
+++ b/DataModule/FiducialMarkWidget.cpp
@@ -13,6 +13,7 @@
 #include "opencv2/video.hpp"
 #include "../Common/CommonFunc.h"
 #include "QDetectObj.h"
+#include "DataUtils.h"
 
 FiducialMarkWidget::FiducialMarkWidget(DataCtrl *pDataCtrl, QWidget *parent)
 :   m_pDataCtrl(pDataCtrl), 
@@ -780,7 +781,7 @@ void FiducialMarkWidget::on_btnDoAlignment_clicked() {
         matTransform.convertTo(matTransform, CV_32FC1);
     }
 
-    auto vecVecTransform = DataUtils::matToVector<float>(matTransform);
+    m_pDataCtrl->setCadTransform(matTransform);
 
     Engine::BoardVector vecBoard;
     auto result = Engine::GetAllBoards(vecBoard);
@@ -813,7 +814,7 @@ void FiducialMarkWidget::on_btnDoAlignment_clicked() {
             if (bBoardRotated)
                 x = m_nBigImageWidth  - x;
             else
-                y = m_nBigImageHeight - y; //In cad, up is positive, but in image, down is positive.        
+                y = m_nBigImageHeight - y; //In cad, up is positive, but in image, down is positive.
 
             std::vector<float> vecSrcPos;
             vecSrcPos.push_back(x);


### PR DESCRIPTION
Fix edit device after alignment position not correct problem.
Also add getCadOffsetPixel function. 
But if the board is rotated, need to use transform function to calculate.